### PR TITLE
Issue #17: Allow configuring ulimits for Tomcat owner

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,4 +18,4 @@ suites:
       - recipe[cerner_tomcat_tester]
     attributes:
       java:
-        jdk_version: 7
+        jdk_version: 8

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Parameters:
  * `env_vars`: A Hash of environment variables to be available when starting tomcat (default = `{}`)
  * `init_info`: A Hash of options to configure the init script. These will be merged with and override the defaults provided (view provider for defaults)
  * `install_java`: A boolean that indicates if we should try to install java (default=`true`)
+ * `limits`: A Hash of limits applied to the owner user of the tomcat process (default=`{ 'open_files' => 32_768, 'max_processes' => 1024 }`)
 
 Example:
 ``` ruby
@@ -59,21 +60,25 @@ cerner_tomcat "my_tomcat" do
   group "my_group"
   base_dir "/opt/my_dir"
   log_dir "/var/log/my_dir"
-  log_rotate_options({
+  log_rotate_options(
     'frequency' => 'daily',
     'size' => '10M',
     'maxsize' => '100M'
-  })
+  )
   version "7.0.49"
   shutdown_timeout 120
-  java_settings({"-Xms" => "512m",
+  java_settings("-Xms" => "512m",
                  "-Xmx" => "512m",
                  "-XX:PermSize=" => "384m",
                  "-XX:MaxPermSize=" => "384m"
-                 "-XX:+UseParNewGC" => ""})
-  env_vars({"MY_VAR" => "MY_VALUE"})
-  init_info({'Default-Start' => '1 2 3 4 5'})
+                 "-XX:+UseParNewGC" => "")
+  env_vars("MY_VAR" => "MY_VALUE")
+  init_info('Default-Start' => '1 2 3 4 5')
   install_java false
+  limits(
+    'open_files' => 32_768,
+    'max_processes' => 1024
+  )
 end
 ```
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,6 +27,7 @@ attribute :java_settings,      kind_of: Hash,    default: {}
 attribute :env_vars,           kind_of: Hash,    default: {}
 attribute :init_info,          kind_of: Hash,    default: {}
 attribute :install_java,       kind_of: [TrueClass, FalseClass],    default: true
+attribute :limits,             kind_of: Hash,    default: {}
 
 def cookbook_file(file_path, &block)
   cookbook_file = ::CernerTomcat::CookbookFileBlock.new(file_path)

--- a/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
+++ b/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
@@ -11,6 +11,10 @@ cerner_tomcat 'my_tomcat' do
                 '-XX:PermSize=' => '384m',
                 '-XX:MaxPermSize=' => '384m')
   init_info('Thing' => 'Value', 'Default-Start' => '1 2 3 4 5')
+  limits(
+    'open_files' => 65_536,
+    'max_processes' => 4096
+  )
 
   cookbook_file 'my_file' do
     source 'my_file'

--- a/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
+++ b/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
@@ -106,3 +106,9 @@ describe file('/opt/my_dir/my_tomcat/bin/setenv.sh') do
   it { should be_grouped_into 'my_group' }
   it { should contain 'export TEST_VAR=TEST_VALUE' }
 end
+
+describe file('/etc/security/limits.d/my_user_limits.conf') do
+  it { should be_file }
+  it { should contain 'my_user - nofile 65536' }
+  it { should contain 'my_user - nproc 4096' }
+end


### PR DESCRIPTION
Relates to #17, where this making it configurable by use of the cerner_tomcat LWRP via a hash.

The integration tests were failing for me out of the box on centos-6.5 with this [failure](https://gist.github.com/cchesser/82c6ca0ac1356275a8b06a790f4651fc). I went ahead and updated the tests to use Java 8. I'm happy if you don't want this to be the case to have a lower Java minimum as part of your default test suite, but I since it is configurable by the consumer, it seemed just as valid to test and leave a default.

test-kitchen results from this change are [here](https://gist.github.com/cchesser/ad4dd2f56dc2dca14eeaf344045d744a).
