### PR TITLE
#16: Offer start_on_install attribute

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -4,3 +4,4 @@ Andrew Olson
 Micah Whitacre
 Tom Boettcher
 Greg Whitsitt
+Carl Chesser

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Parameters:
  * `init_info`: A Hash of options to configure the init script. These will be merged with and override the defaults provided (view provider for defaults)
  * `install_java`: A boolean that indicates if we should try to install java (default=`true`)
  * `limits`: A Hash of limits applied to the owner user of the tomcat process (default=`{ 'open_files' => 32_768, 'max_processes' => 1024 }`)
+ * `start_on_install`: A boolean that indicates if the service should be started immediately
+ on installation. On a fresh installation, you generally will always restart the service
+ process, so this may be used as a deployment optimization to avoid a start and later
+ restart of the service (default=`true`).
 
 Example:
 ``` ruby

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -227,11 +227,15 @@ action :install do
   end
 
   # Enable tomcat instance, :enable adds service to startup,
-  # :start starts service if it isn't already started
-  [:enable] << :start if new_resource.start_on_install
+  # :start starts service if it isn't already started. 
+  # :start will be conditionally applied, as the service restart will
+  # always be restarted at the end of convergence if any file that
+  # requires service restart is triggered.
+  service_actions = [:enable]
+  service_actions << :start if new_resource.start_on_install
   service "tomcat_#{new_resource.instance_name}" do
     supports status: true, restart: true
-    action [:enable, :start]
+    action service_actions
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -228,6 +228,7 @@ action :install do
 
   # Enable tomcat instance, :enable adds service to startup,
   # :start starts service if it isn't already started
+  [:enable] << :start if new_resource.start_on_install
   service "tomcat_#{new_resource.instance_name}" do
     supports status: true, restart: true
     action [:enable, :start]

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -28,6 +28,7 @@ attribute :env_vars,           kind_of: Hash,    default: {}
 attribute :init_info,          kind_of: Hash,    default: {}
 attribute :install_java,       kind_of: [TrueClass, FalseClass],    default: true
 attribute :limits,             kind_of: Hash,    default: {}
+attribute :start_on_install,   kind_of: [TrueClass, FalseClass],    default: true
 
 def cookbook_file(file_path, &block)
   cookbook_file = ::CernerTomcat::CookbookFileBlock.new(file_path)

--- a/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
+++ b/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
@@ -31,6 +31,8 @@ cerner_tomcat 'my_tomcat' do
 
   health_check 'http://localhost:8080/my_webapp/hello'
 
+  start_on_install false
+
   web_app 'my_webapp' do
     source 'http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war'
 

--- a/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
+++ b/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
@@ -29,12 +29,22 @@ cerner_tomcat 'my_tomcat' do
     variables(key: 'tomcat_my_template')
   end
 
-  health_check 'http://localhost:8080/my_webapp/hello'
+  template 'conf/server.xml' do
+    source 'server.xml.erb'
+    variables(
+      'port' => {
+        'connector' => 8001,
+        'shutdown' => 8002,
+        'ajp' => 8003,
+      })
+  end
+
+  health_check 'http://localhost:8001/my_webapp/hello'
 
   start_on_install false
 
   web_app 'my_webapp' do
-    source 'http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war'
+    source 'http://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war'
 
     cookbook_file 'my_file' do
       source 'my_file'
@@ -48,5 +58,43 @@ cerner_tomcat 'my_tomcat' do
       source 'my_template.erb'
       variables(key: 'web_app_template')
     end
+  end
+end
+
+# Including a secondary instance to test delay service starting
+# between installations
+cerner_tomcat 'my_tomcat_2' do
+  user 'my_user'
+  group 'my_group'
+  base_dir '/opt/my_dir'
+  log_dir '/opt/my_logs'
+  log_rotate_options('rotate' => 1)
+  env_vars('TEST_VAR' => 'TEST_VALUE')
+  java_settings('-Xms' => '512m',
+                '-Xmx' => '512m',
+                '-XX:PermSize=' => '384m',
+                '-XX:MaxPermSize=' => '384m')
+  init_info('Thing' => 'Value', 'Default-Start' => '1 2 3 4 5')
+  limits(
+    'open_files' => 65_536,
+    'max_processes' => 4096
+  )
+
+  template 'conf/server.xml' do
+    source 'server.xml.erb'
+    variables(
+      'port' => {
+        'connector' => 8011,
+        'shutdown' => 8012,
+        'ajp' => 8013,
+      })
+  end
+
+  health_check 'http://localhost:8011/my_webapp/hello'
+
+  start_on_install false
+
+  web_app 'my_webapp' do
+    source 'http://tomcat.apache.org/tomcat-8.0-doc/appdev/sample/sample.war'
   end
 end

--- a/test/cookbooks/cerner_tomcat_tester/templates/default/server.xml.erb
+++ b/test/cookbooks/cerner_tomcat_tester/templates/default/server.xml.erb
@@ -1,0 +1,142 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="<%= @port['shutdown'] %>" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="<%= @port['connector'] %>" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation that requires the JSSE
+         style configuration. When using the APR/native implementation, the
+         OpenSSL style configuration is required as described in the APR/native
+         documentation -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
+               clientAuth="false" sslProtocol="TLS" />
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <Connector port="<%= @port['ajp'] %>" protocol="AJP/1.3" redirectPort="8443" />
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
+++ b/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
@@ -11,10 +11,15 @@ describe service('my_tomcat') do
   it { should be_running   }
 end
 
-# There should only be 1 java process running
+describe service('my_tomcat_2') do
+  it { should be_running   }
+end
+
+# Verify both of the services running (2 of them)
 describe process('java') do
-  its(:user) { should eq 'my_user' }
-  its(:args) { should match /-Xms512m -Xmx512m -XX:PermSize=384m -XX:MaxPermSize=384m/ }
+  its(:count) { should eq 2 }
+  its(:user)  { should eq 'my_user' }
+  its(:args)  { should match /-Xms512m -Xmx512m -XX:PermSize=384m -XX:MaxPermSize=384m/ }
 end
 
 describe file('/opt/my_dir/my_tomcat/my_file') do


### PR DESCRIPTION
This change relates to issue #16, where `:start` is conditionally included. This is to allow consumers to dictate if service start should be applied immediately on install. Generally, this can be delayed as service restart will be applied at the end of the chef-client run.

test-kitchen verify results are [here](https://gist.github.com/cchesser/26191db09a4864d2b0fc9512492a2ad2). Note, I didn't change the tests, as they already verify the service process is running at the end of convergence.
