### PR TITLE
Issue-15: Flag to disable user/group creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Parameters:
  on installation. On a fresh installation, you generally will always restart the service
  process, so this may be used as a deployment optimization to avoid a start and later
  restart of the service (default=`true`).
+ * `create_user`: A boolean that indicates if the service user should be created (default=`true`)
 
 Example:
 ``` ruby

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -18,14 +18,16 @@ action :install do
   end
 
   # Setup user/group
-  group new_resource.group do
+  group new_resource.group do # ~FC021 -- Fixed in 10.18.0, not likely to be an issue either way
     action :create
     notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
+    only_if { new_resource.create_user }
   end
 
-  user new_resource.user do
+  user new_resource.user do # ~FC021 -- Fixed in 10.18.0, not likely to be an issue either way
     gid new_resource.group
     notifies :restart, "service[tomcat_#{new_resource.instance_name}]"
+    only_if { new_resource.create_user }
   end
 
   limits_defaults = { 'open_files' => 32_768, 'max_processes' => 1024 }

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -29,6 +29,7 @@ attribute :init_info,          kind_of: Hash,    default: {}
 attribute :install_java,       kind_of: [TrueClass, FalseClass],    default: true
 attribute :limits,             kind_of: Hash,    default: {}
 attribute :start_on_install,   kind_of: [TrueClass, FalseClass],    default: true
+attribute :create_user,        kind_of: [TrueClass, FalseClass],    default: true
 
 def cookbook_file(file_path, &block)
   cookbook_file = ::CernerTomcat::CookbookFileBlock.new(file_path)

--- a/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
+++ b/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
@@ -79,6 +79,7 @@ cerner_tomcat 'my_tomcat_2' do
     'open_files' => 65_536,
     'max_processes' => 4096
   )
+  create_user false
 
   template 'conf/server.xml' do
     source 'server.xml.erb'


### PR DESCRIPTION
Pull serving as review.

Wasn't sure of how to automate testing for this feature, but manually tested by setting create_user on the the second tomcat installation in the tests (change include in pull) and can verify that the actions are being skipped in the output of run:

> ```
>       * group[my_group] action create (skipped due to only_if)
>       * linux_user[my_user] action create (skipped due to only_if)
> ```
