### PR TITLE
Issue #21: Terminating find_pid expression with '/'

### DIFF
--- a/templates/default/tomcat_init.sh.erb
+++ b/templates/default/tomcat_init.sh.erb
@@ -138,7 +138,7 @@ wasSuccessful() {
 }
 
 find_pid() {
-  PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`
+  PID=`pgrep -u $USER -f "$CATALINA_HOME .*$START_CLASS"`
 }
 
 case "$1" in

--- a/templates/default/tomcat_init.sh.erb
+++ b/templates/default/tomcat_init.sh.erb
@@ -138,7 +138,7 @@ wasSuccessful() {
 }
 
 find_pid() {
-  PID=`pgrep -u $USER -f "$CATALINA_HOME.*$START_CLASS"`
+  PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`
 }
 
 case "$1" in

--- a/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
+++ b/test/cookbooks/cerner_tomcat_tester/recipes/default.rb
@@ -1,7 +1,23 @@
 
+# The kitchen tests are configuring the manage the user outside of cerner_tomcat.
+# As a result, we will manage it separately from the provider.
+tomcat_user = 'my_user'
+tomcat_group = 'my_group'
+
+# Setup user/group
+group tomcat_group do
+  action :create
+end
+
+user tomcat_user do
+  gid tomcat_group
+  home "/home/#{tomcat_user}"
+  manage_home true
+end
+
 cerner_tomcat 'my_tomcat' do
-  user 'my_user'
-  group 'my_group'
+  user tomcat_user
+  group tomcat_group
   base_dir '/opt/my_dir'
   log_dir '/opt/my_logs'
   log_rotate_options('rotate' => 1)
@@ -123,8 +139,8 @@ end
 # Including a secondary instance to test delay service starting
 # between installations
 cerner_tomcat 'my_tomcat_2' do
-  user 'my_user'
-  group 'my_group'
+  user tomcat_user
+  group tomcat_group
   base_dir '/opt/my_dir'
   log_dir '/opt/my_logs'
   log_rotate_options('rotate' => 1)

--- a/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
+++ b/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
@@ -135,6 +135,7 @@ describe file('/etc/init.d/tomcat_my_tomcat') do
   it { should contain '# Provides: my_tomcat' }
   it { should contain '# Default-Stop: 0 1 2 6' }
   it { should contain 'HC_CODE=$(healthCheck http://localhost:8001/my_webapp/hello GET 3 )' }
+  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`' } 
 end
 
 describe file('/etc/init.d/tomcat_my_tomcat_2') do
@@ -146,6 +147,7 @@ describe file('/etc/init.d/tomcat_my_tomcat_2') do
   it { should contain '# Provides: my_tomcat_2' }
   it { should contain '# Default-Stop: 0 1 2 6' }
   it { should contain 'HC_CODE=$(healthCheck http://localhost:8011/my_webapp/hello GET 3 -k)' }
+  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`' } 
 end
 
 describe file('/opt/my_dir/my_tomcat/bin/setenv.sh') do

--- a/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
+++ b/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe user('my_user') do
   it { should exist }
   it { should belong_to_group 'my_group' }
+  it { should have_home_directory '/home/my_user' }
 end
 
 describe service('my_tomcat') do
@@ -135,7 +136,7 @@ describe file('/etc/init.d/tomcat_my_tomcat') do
   it { should contain '# Provides: my_tomcat' }
   it { should contain '# Default-Stop: 0 1 2 6' }
   it { should contain 'HC_CODE=$(healthCheck http://localhost:8001/my_webapp/hello GET 3 )' }
-  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`' } 
+  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME .*$START_CLASS"`' } 
 end
 
 describe file('/etc/init.d/tomcat_my_tomcat_2') do
@@ -147,7 +148,7 @@ describe file('/etc/init.d/tomcat_my_tomcat_2') do
   it { should contain '# Provides: my_tomcat_2' }
   it { should contain '# Default-Stop: 0 1 2 6' }
   it { should contain 'HC_CODE=$(healthCheck http://localhost:8011/my_webapp/hello GET 3 -k)' }
-  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME/.*$START_CLASS"`' } 
+  it { should contain 'PID=`pgrep -u $USER -f "$CATALINA_HOME .*$START_CLASS"`' } 
 end
 
 describe file('/opt/my_dir/my_tomcat/bin/setenv.sh') do


### PR DESCRIPTION
Applying the fix to terminate the expression used to qualify service processes PIDs.

Fixes: #21 

Test kitchen verify results are [here](https://gist.github.com/cchesser/df0214c29b89e2721d00cc4623a94e63).
