### PR TITLE
Issue 5: Adding support for force shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Parameters:
  * `log_rotate_options`: A hash or ruby block of options to configure log rotate. These will be merged with and override the defaults provided (view `libraries/cerner_tomcat.rb` for defaults)
  * `version`: The version of tomcat to install. This effectively builds the tomcat_url from a known URL (`repo1.maven.org`) with the given version (default=`8.0.21`)
  * `tomcat_url`: The URL to the tomcat binary used to install tomcat. This will override the url provided by `version`. NOTE: `version` needs to still be up to date in order to install tomcat properly
- * `shutdown_timeout`: The timeout used when trying to shutdown the tomcat service (default = `60`)
+ * `shutdown_timeout`: The timeout used when trying to shutdown the tomcat service (default = `60`). If the timeout is reached, diagnostics are captured about the instance
+ and the a force shutdown is applied.
  * `java_settings`: A Hash of java settings to be applied to the tomcat process (default = `{}`)
  * `env_vars`: A Hash of environment variables to be available when starting tomcat (default = `{}`)
  * `init_info`: A Hash or ruby block of options to configure the init script. These will be merged with and override the defaults provided (view `libraries/cerner_tomcat.rb` for defaults)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ cerner_tomcat "my_tomcat" do
 end
 ```
 
+### Troubleshooting
+
+The cookbook additionally configures a `diagnostic` command option as part of the `sysvinit` installation of the service. This command
+captures various metrics of the JVM and bundles it in a `tar.gz` within a temp directory for later evaluation. Diagnostics which are
+included in this bundle:
+
+* JVM performance counters: Series of stats on the JVM, which are a lot of simple facts of the run-time at a low cost of acquiring
+(filename: `<service_name>_perfcount.log`).
+* JVM thread dump: Helpful to identify non-daemon threads and JVM information about each thread with their native thread ID
+(filename: `<service_name>_thread_dump.log`).
+* Native thread logs: Helpful to correlate CPU utilization to native threads which are tied to in the JVM thread dump with the 
+native thread ID (nid). These are samplings from `top` which include native thread utilization (filename: `<service_name>_native_thread.log`).
+* JVM GC class histogram: Helpful if JVM seems hung, and identified GC threads are utilizing high CPU, to then evaluate the amount 
+of objects / types being created (filename: `<service_name>_gc_class_histogram.log`).
+
+If using the `sysvinit` installation of the service, and the Tomcat service does not shutdown in a timely manner (within the defined 
+timeout period), it will include a thread dump as part of the service stdout (ex. `catalina.out`), and may additionally invoke this
+diagnostic bundle to be created before forcing the service process to shutdown (through an OS signal). This can be helpful to further
+evaluate if a service is consistently requiring a forceful shutdown (web application may have a non-daemon thread not being shutdown).
+
 Contributing
 ------------
 

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -8,3 +8,5 @@ export <%= k %>=<%= v %>
 # Java settings
 export CATALINA_OPTS="$CATALINA_OPTS <%= @java_settings.map{|k,v| k.to_s + v.to_s }.join(" ") %>"
 <% end -%>
+
+CATALINA_PID="$CATALINA_BASE/bin/catalina.pid"

--- a/templates/default/tomcat_init.sh.erb
+++ b/templates/default/tomcat_init.sh.erb
@@ -64,33 +64,23 @@ start() {
 }
 
 stop() {
-  echo "Shutting down $NAME:"
+  SHUTDOWN_CMD="$CATALINA_HOME/bin/shutdown.sh"
 
+  # We are not supplying the "force" option initially, as we want to 
+  # capture thread dumps to catalina.out if the service is not responding
+  # on normal shutdown. Using this option, and defining CATALINA_PID,
+  # it will also attempt to send a SIGTERM OS signal to the process
+  # if the shutdown port is not responding.
+  su -l $USER -c "$SHUTDOWN_CMD $TIMEOUT"
+
+  # Failed to shutdown both through the shutdown port / SIGTERM. Will
+  # capture a diagnostic bundle, and then do a force (SIGKILL) shutdown.
   find_pid
-
-  CURRENT_WAIT=0
-
-  # Wait until tomcat has successfully stopped
-  while [[ $PID -gt 0 ]];
-  do
-    echo "Attempting to shutdown $NAME..."
-    su -l $USER -c $CATALINA_HOME/bin/shutdown.sh
-
-    if [[ $? -ne 0 ]]; then
-      echo "Error stopping $NAME"
-      exit 1
-    fi
-
-    sleep $SLEEP_TIME
-    CURRENT_WAIT=$(($CURRENT_WAIT+$SLEEP_TIME))
-    if [[ $CURRENT_WAIT -gt $TIMEOUT ]]; then
-      echo "Timed out waiting for $NAME to stop"
-      exit 1
-    fi
-
-    find_pid
-  done
-  echo "$NAME has stopped"
+  if [[ $PID -gt 0 ]]; then
+    echo "Capturing diagnostics and then forcing shutdown..."
+    diagnostic
+    su -l $USER -c "$SHUTDOWN_CMD 1 -force"
+  fi
 }
 
 status() {
@@ -116,6 +106,42 @@ health() {
     fi
     <% end %>
     exit $EXIT_CODE
+}
+
+diagnostic() { 
+    find_pid   
+    TMP_DIR=<%= Chef::Config[:file_cache_path] %>
+    PARENTDIR=`mktemp -d ${TMP_DIR}/${NAME}.XXXXXX`
+    DIR=$PARENTDIR/diag
+    mkdir $DIR
+    chown $USER $PARENTDIR $DIR
+    echo "Capturing JVM metrics of $NAME ($PID):"
+    
+    echo "Capturing native thread state..."
+    FILE="${DIR}/${NAME}_native_thread.log"
+    su $USER -c "top -b -n3 -H -p $PID > $FILE"
+    
+    echo "Capturing JVM performance metrics..."
+    FILE="${DIR}/${NAME}_perfcount.log"
+    su $USER -c "jcmd $PID PerfCounter.print > $FILE"
+    
+    echo "Capturing JVM thread dump..."
+    FILE="${DIR}/${NAME}_thread_dump.log"
+    su $USER -c "jcmd $PID Thread.print > $FILE"
+    
+    echo "Capturing JVM class histogram..."
+    FILE="${DIR}/${NAME}_gc_class_histogram.log"
+    su $USER -c "jcmd $PID GC.class_histogram > $FILE"
+        
+    # Create a tar.gz file with the diagnostic files
+    echo "Compressing contents..."
+    TIMESTAMP=`date +"%Y%m%d%H%M"`
+    HOST=`hostname`
+    TARFILE="${PARENTDIR}/${NAME}_${HOST}_${PID}_${TIMESTAMP}.tar.gz"
+    tar -czvf $TARFILE -C $DIR . > /dev/null 2>&1
+    # Remove the files which are now included in the archive
+    rm -rf $DIR
+    echo "Diagnostic information included in: $TARFILE"
 }
 
 # Runs an HTTP health check against the specified URI.
@@ -161,7 +187,10 @@ case "$1" in
   health)
     health
   ;;
+  diagnostic)
+    diagnostic
+  ;;
   *)
-    echo "Usage: tomcat_$NAME {start|stop|restart|status|health}"
+    echo "Usage: tomcat_$NAME {start|stop|restart|status|health|diagnostic}"
     exit 1
 esac

--- a/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
+++ b/test/integration/default/serverspec/cerner_tomcat_tester_spec.rb
@@ -169,10 +169,16 @@ describe file('/opt/my_dir/my_tomcat/bin/setenv.sh') do
   it { should be_owned_by 'my_user' }
   it { should be_grouped_into 'my_group' }
   it { should contain 'export TEST_VAR=TEST_VALUE' }
+  it { should contain 'CATALINA_PID="$CATALINA_BASE/bin/catalina.pid"' }
 end
 
 describe file('/etc/security/limits.d/my_user_limits.conf') do
   it { should be_file }
   it { should contain 'my_user - nofile 65536' }
   it { should contain 'my_user - nproc 4096' }
+end
+
+describe command('service tomcat_my_tomcat diagnostic') do
+  its(:stdout) { should match /Capturing JVM metrics of my_tomcat \(\d+\)\:/ }
+  its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
## Overview

Applying changes described in #5. This includes a new `diagnostic` command that can capture the following information:
* JVM performance counters: Series of stats on the JVM (a lot of simple facts of the run-time at a low cost of acquiring)
* JVM thread dump: Helpful to identify non-daemon threads and JVM information about each thread with their native thread ID.
* Native thread logs: Helpful to correlate CPU utilization to native threads (which are tied to in the JVM thread dump with the native thread ID).
* JVM GC class histogram (helpful if JVM seems hung, and identified GC threads are utilizing high CPU, to then evaluate the amount of objects / types being created)

Changed init.d script to leverage the `stop` option with force once it is unable to stop the process. By having the `CATALINA_PID` defined, the catalina.sh script will capture a thread dump and include it in stdout (catalina.out) when it attempts but is unable on the first stop it.

## Test

I updated the serverspec tests to test just the existing applications, but did my own test to build a bad web application that creates a non-daemon thread to hang the JVM up on shutdown. Here is the example log (which ultimately shuts down the process):

```
[vagrant@default-centos-67 ~]$ sudo service tomcat_my_tomcat stop
Using CATALINA_BASE:   /opt/my_dir/my_tomcat
Using CATALINA_HOME:   /opt/my_dir/my_tomcat
Using CATALINA_TMPDIR: /opt/my_dir/my_tomcat/temp
Using JRE_HOME:        /usr/lib/jvm/java-1.8.0
Using CLASSPATH:       /opt/my_dir/my_tomcat/bin/bootstrap.jar:/opt/my_dir/my_tomcat/bin/tomcat-juli.jar
Using CATALINA_PID:    /opt/my_dir/my_tomcat/bin/catalina.pid
Tomcat did not stop in time. PID file was not removed. To aid diagnostics a thread dump has been written to standard out.
Capturing diagnostics and then forcing shutdown...
Capturing JVM metrics of my_tomcat (10633):
Capturing native thread state...
Capturing JVM performance metrics...
Capturing JVM thread dump...
Capturing JVM class histogram...
Compressing contents...
Diagnostic information included in: /tmp/kitchen/cache/my_tomcat.GFwZ9M/my_tomcat_default-centos-67_10633_201612272146.tar.gz
Using CATALINA_BASE:   /opt/my_dir/my_tomcat
Using CATALINA_HOME:   /opt/my_dir/my_tomcat
Using CATALINA_TMPDIR: /opt/my_dir/my_tomcat/temp
Using JRE_HOME:        /usr/lib/jvm/java-1.8.0
Using CLASSPATH:       /opt/my_dir/my_tomcat/bin/bootstrap.jar:/opt/my_dir/my_tomcat/bin/tomcat-juli.jar
Using CATALINA_PID:    /opt/my_dir/my_tomcat/bin/catalina.pid
Dec 27, 2016 9:46:48 PM org.apache.catalina.startup.Catalina stopServer
SEVERE: Could not contact localhost:8002. Tomcat may not be running.
Dec 27, 2016 9:46:48 PM org.apache.catalina.startup.Catalina stopServer
SEVERE: Catalina.stop:
java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at java.net.Socket.connect(Socket.java:538)
	at java.net.Socket.<init>(Socket.java:434)
	at java.net.Socket.<init>(Socket.java:211)
	at org.apache.catalina.startup.Catalina.stopServer(Catalina.java:450)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.catalina.startup.Bootstrap.stopServer(Bootstrap.java:400)
	at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:487)

The stop command failed. Attempting to signal the process to stop through OS signal.
Tomcat stopped.
```
If you want to check out what some of the diagnostic files look like, [here is a gist that captures this test](https://gist.github.com/cchesser/f4a24ae18542fe0359720804c07ebb3d).

Here is the [kitchen test evidence](https://gist.github.com/cchesser/4a9523a55ebe9032a999a1a3df022a01)