### PR TITLE
Use download_dir for diagnostics

### DIFF
--- a/templates/default/tomcat_init.sh.erb
+++ b/templates/default/tomcat_init.sh.erb
@@ -112,7 +112,7 @@ health() {
 
 diagnostic() {
     find_pid
-    TMP_DIR=<%= Chef::Config[:file_cache_path] %>
+    TMP_DIR=<%= content.download_dir %>
     PARENTDIR=`mktemp -d ${TMP_DIR}/${NAME}.XXXXXX`
     DIR=$PARENTDIR/diag
     mkdir $DIR


### PR DESCRIPTION
Since download_dir is guarantee to be owned by the tomcat user, use it to run the diagnostic script.