### PR TITLE
Changed default tomcat URL to https

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,3 +7,4 @@ Greg Whitsitt
 Carl Chesser
 Edward 'Cole' Skoviak
 Seth Verrinder
+Sanket Prabhu

--- a/libraries/cerner_tomcat.rb
+++ b/libraries/cerner_tomcat.rb
@@ -94,7 +94,7 @@ module CernerTomcat
         end
 
         def default_tomcat_url
-          "http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/#{version}/tomcat-#{version}.tar.gz"
+          "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat/#{version}/tomcat-#{version}.tar.gz"
         end
 
         private


### PR DESCRIPTION
I changed the following URL to HTTPS
https://support.sonatype.com/hc/en-us/articles/360041287334

def default_tomcat_url

**from** 

"http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/#{version}/tomcat-#{version}.tar.gz"
end

**to** 

"https://repo1.maven.org/maven2/org/apache/tomcat/tomcat/#{version}/tomcat-#{version}.tar.gz"
end